### PR TITLE
Add isolation and validation

### DIFF
--- a/src/main/scala/sss/db/Tx.scala
+++ b/src/main/scala/sss/db/Tx.scala
@@ -1,0 +1,109 @@
+package sss.db
+
+import java.sql.Connection
+
+import javax.sql.DataSource
+import sss.ancillary.Logging
+
+import scala.util.Try
+import scala.util.control.NonFatal
+
+private[db] case class ConnectionTracker(conn: Connection, count: Int)
+
+private[db] object Tx extends ThreadLocal[ConnectionTracker]
+
+trait Tx extends Logging {
+
+  private[db] val ds: DataSource
+  private[db] def conn: Connection = Tx.get.conn
+
+
+  def startTx(): Boolean = {
+    Option(Tx.get()) match {
+      case None =>
+        // auto commit should be off by default
+        Tx.set(ConnectionTracker(ds.getConnection, 0))
+        true
+      case Some(existing) =>
+        Tx.set(ConnectionTracker(existing.conn, existing.count + 1))
+        false
+    }
+
+  }
+
+  def startTx(isolationLevel: Int): Boolean = {
+    Option(Tx.get()) match {
+      case None =>
+        // auto commit should be off by default
+        val c = ds.getConnection
+        c.setTransactionIsolation(isolationLevel)
+        Tx.set(ConnectionTracker(c, 0))
+        true
+      case Some(existing) =>
+
+        require(existing.conn.getTransactionIsolation() == isolationLevel,
+          s"Required isolation level ($isolationLevel) must be same as " +
+            s"existing level (${existing.conn.getTransactionIsolation()})")
+
+        Tx.set(ConnectionTracker(existing.conn, existing.count + 1))
+        false
+    }
+
+  }
+
+  def closeTx = {
+    Option(Tx.get) match {
+      case None => throw new IllegalStateException("Closing a non existing tx?")
+      case Some(existing) if existing.count == 0 =>
+        existing.conn.close
+        Tx.remove
+      case Some(existing) =>
+        Tx.set(ConnectionTracker(existing.conn, existing.count - 1))
+    }
+  }
+
+  def tx[T](f: => T): T = inTransaction[T](f)
+
+  def validateTx[T](isolationLevel: Option[Int] = None)(f: => T): Try[T] = Try {
+
+    val txStarted = isolationLevel map (startTx(_)) getOrElse (startTx())
+
+    require(txStarted, "Must validate in standalone tx")
+
+    try {
+      f
+    } finally {
+      conn.rollback()
+      closeTx
+    }
+  }
+
+  def validateTx[T](f: => T): Try[T] = Try {
+
+    require(startTx(), "Must validate in standalone tx")
+
+    try {
+      f
+    } finally {
+      conn.rollback()
+      closeTx
+    }
+  }
+
+  def inTransaction[T](f: => T): T = {
+    val isNew = startTx()
+    try {
+      val r = f
+      if (isNew) conn.commit()
+      r
+    } catch {
+      case NonFatal(e) =>
+        log.debug("ROLLING BACK!", e)
+        conn.rollback
+        throw e
+    } finally {
+      closeTx
+    }
+
+  }
+}

--- a/src/main/scala/sss/db/datasource/DataSource.scala
+++ b/src/main/scala/sss/db/datasource/DataSource.scala
@@ -27,5 +27,6 @@ trait DataSourceConfig {
   val connectionProperties: String
   val user: String
   val pass: String
+  val transactionIsolationLevel: String
 }
 

--- a/src/main/scala/sss/db/datasource/HikariDataSource.scala
+++ b/src/main/scala/sss/db/datasource/HikariDataSource.scala
@@ -26,7 +26,7 @@ object HikariDataSource {
     hikariConfig.setPassword(dsConfig.pass)
     hikariConfig.setAutoCommit(false)
     hikariConfig.setIsolateInternalQueries(true)
-    hikariConfig.setTransactionIsolation("TRANSACTION_REPEATABLE_READ")
+    hikariConfig.setTransactionIsolation(dsConfig.transactionIsolationLevel)
 
     hikariConfig.setMaximumPoolSize(dsConfig.maxPoolSize)
     dsConfig.testQueryOpt map (hikariConfig.setConnectionTestQuery(_))

--- a/src/main/scala/sss/db/datasource/HikariDataSource.scala
+++ b/src/main/scala/sss/db/datasource/HikariDataSource.scala
@@ -26,6 +26,7 @@ object HikariDataSource {
     hikariConfig.setPassword(dsConfig.pass)
     hikariConfig.setAutoCommit(false)
     hikariConfig.setIsolateInternalQueries(true)
+    hikariConfig.setTransactionIsolation("TRANSACTION_REPEATABLE_READ")
 
     hikariConfig.setMaximumPoolSize(dsConfig.maxPoolSize)
     dsConfig.testQueryOpt map (hikariConfig.setConnectionTestQuery(_))

--- a/src/main/scala/sss/db/package.scala
+++ b/src/main/scala/sss/db/package.scala
@@ -128,6 +128,8 @@ package object db {
       case x => false
     }
 
+    def id: Long = apply[Long]("id")
+
     override def hashCode = asMap.hashCode
 
     def get(col: String) = asMap(col.toLowerCase)

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -11,6 +11,7 @@ testDb {
     prepStmtCacheSize = 250
     prepStmtCacheSqlLimit = 2048
     useServerPrepStmts = true
+    transactionIsolationLevel = "TRANSACTION_READ_COMMITTED"
   }
 
   viewCachesSize = 100

--- a/src/test/scala/sss/db/DbSpec.scala
+++ b/src/test/scala/sss/db/DbSpec.scala
@@ -10,7 +10,9 @@ class DbSpec extends
     new PagedViewSpec,
     new ForComprehensionSpec,
     new SqlInterpolatorSpec,
-    new ParallelThreadSupportSpec
+    new ParallelThreadSupportSpec,
+    new ValidateTransactionSpec,
+    new SetIsolationLevelSupportSpec
   ) with
   BeforeAndAfterAll with
   SequentialNestedSuiteExecution {

--- a/src/test/scala/sss/db/SetIsolationLevelSupportSpec.scala
+++ b/src/test/scala/sss/db/SetIsolationLevelSupportSpec.scala
@@ -1,0 +1,58 @@
+package sss.db
+
+import java.sql.{Connection, SQLTransactionRollbackException}
+import java.util.Date
+
+import org.scalatest.DoNotDiscover
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.language.postfixOps
+import scala.util.{Failure, Success, Try}
+
+@DoNotDiscover
+class SetIsolationLevelSupportSpec extends DbSpecSetup {
+
+  def parallelEffect(j: Int): Try[(Long, Long)] = {
+    Try {
+      fixture.table.tx(Connection.TRANSACTION_SERIALIZABLE, {
+        val tname = Thread.currentThread().getName
+        val c = fixture.table.count
+        val i = fixture.table.insert(j, s"strId $j", new Date().getTime, j)
+        assert(i === 1, "should only insert 1 row")
+        (c, fixture.table.count)
+      })
+      //println(s"$tname result is new=$nc inserted=$i old count=$c ")
+    } recoverWith {
+      case e: SQLTransactionRollbackException => {
+        //println(e)
+        parallelEffect(j)
+      }
+    }
+  }
+
+
+  def futureParallelEffect(j: Int):Future[Try[(Long, Long)]] = Future (parallelEffect(j))
+
+
+
+  it should "support TRANSACTION_SERIALIZABLE " in {
+    val testCount = 100
+    val effects = for {
+      i <- (0 until testCount)
+    } yield(futureParallelEffect(i))
+
+    effects.foreach { effect =>
+      Await.result(effect, 10 seconds) match {
+        case Failure(e) => fail("No idea? ")
+        case Success(c) => assert(c._1 + 1 === c._2, "Counts should be incremental")
+      }
+
+    }
+    assert(fixture.table.count === testCount, s"Should only be $testCount rows inserted")
+  }
+
+
+
+}

--- a/src/test/scala/sss/db/ValidateTransactionSpec.scala
+++ b/src/test/scala/sss/db/ValidateTransactionSpec.scala
@@ -1,0 +1,42 @@
+package sss.db
+
+import java.util.Date
+
+import org.scalatest._
+
+import scala.util.{Failure, Success}
+
+@DoNotDiscover
+class ValidateTransactionSpec extends DbSpecSetup {
+
+
+  "A Transaction" should "validate without being persisted" in {
+    val time = new Date()
+    fixture.table.validateTx(
+      fixture.table.insert(Map(("strId" -> "strId"), ("createTime" -> time), ("intVal" -> 67)))
+    ) match {
+      case Failure(_) => fail("Should pass")
+      case Success(row) => {
+        // l is id of new record, which should not exist
+        assert(fixture.table.get(row.id).isEmpty, "Should have rolled back")
+      }
+    }
+  }
+
+  "A bad Transaction" should "validate (to failure) without being persisted" in {
+    val time = new Date()
+    fixture.table.validateTx {
+      val maxId = fixture.table.maxId
+      val row = fixture.table.insert(Map(("strId" -> "strId"), ("createTime" -> time), ("intVal" -> 67)))
+      val newMaxId = fixture.table(row.id).id
+      assert(maxId + 1 == newMaxId)
+      fixture.table(newMaxId + 1) // <- cannot exist
+    } match {
+      case Failure(e: DbException) => //println(e)
+      case _ => {
+        // l is id of new record, which should not exist
+        fail("Should have failed")
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Allow a data source to have a default isolation level 
- Allow a transaction to start with a particular isolation level connection 
- Allow a transaction to run against the database but not committed. 